### PR TITLE
New release: 2024a

### DIFF
--- a/.github/workflows/test-fresh-installation.yml
+++ b/.github/workflows/test-fresh-installation.yml
@@ -45,7 +45,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install libgl1 libegl -y
+          sudo apt-get install libgl1 libegl1 -y
       - name: Run installation script ${{ matrix.install_script }} for ${{ matrix.os }}
         run: ${{ matrix.install_script }}
       - name: Activate environment ${{ env.ncEnv }} and run tests on ${{ matrix.os }}

--- a/.github/workflows/test-fresh-installation.yml
+++ b/.github/workflows/test-fresh-installation.yml
@@ -4,7 +4,7 @@ on: [push]
 env:
   ncDebug: 1
   ncCI: 1
-  ncEnv: neuro-conda-2023b
+  ncEnv: neuro-conda-2024a
 jobs:
   Test-Install:
     name: Install (${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/test-fresh-installation.yml
+++ b/.github/workflows/test-fresh-installation.yml
@@ -45,7 +45,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install libgl1 -y
+          sudo apt-get install libgl1 libegl -y
       - name: Run installation script ${{ matrix.install_script }} for ${{ matrix.os }}
         run: ${{ matrix.install_script }}
       - name: Activate environment ${{ env.ncEnv }} and run tests on ${{ matrix.os }}

--- a/.github/workflows/test-fresh-installation.yml
+++ b/.github/workflows/test-fresh-installation.yml
@@ -34,8 +34,7 @@ jobs:
       run:
         shell: ${{ matrix.use_shell }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        runs-on: ubuntu-latest
+      - name: Free Disk Space (Ubuntu)        
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,

--- a/.github/workflows/test-fresh-installation.yml
+++ b/.github/workflows/test-fresh-installation.yml
@@ -34,6 +34,22 @@ jobs:
       run:
         shell: ${{ matrix.use_shell }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        runs-on: ubuntu-latest
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Download repository
         uses: actions/checkout@v3
       - name: Install system packages on Linux

--- a/.github/workflows/test-fresh-installation.yml
+++ b/.github/workflows/test-fresh-installation.yml
@@ -35,20 +35,10 @@ jobs:
         shell: ${{ matrix.use_shell }}
     steps:
       - name: Free Disk Space (Ubuntu)        
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-          
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Download repository
         uses: actions/checkout@v3
       - name: Install system packages on Linux

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 **Updated**
 
-- dataconf 2.1 dataconf 2.5
+- dataconf 2.1 &rarr; 2.5
 - dipy 1.7 &rarr; 1.8
 - elephant 0.14 &rarr; 1.0
 - esi-acme 2023.4 &rarr; 2023.12
@@ -15,7 +15,6 @@
 - mne 1.5 &rarr; 1.6
 - mne-icalabel 0.4 &rarr; 0.6
 - mne-nirs 0.5 &rarr; 0.6
-- mnelab &rarr; 0.9
 - neo 0.12 &rarr; 0.13
 - pywavelets 1.4 &rarr; 1.5
 - scikit-image 0.20 &rarr; 0.22

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 
 3rd release of neuro-conda with a few updates.
 
+**Added**
+
+- ephyviewer 1.5
+
 **Updated**
 
 - dataconf 2.1 &rarr; 2.5

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,35 @@
 # Release Notes for neuro-conda
 
+## neuro-conda-2024a
+
+3rd release of neuro-conda with a few updates.
+
+**Updated**
+
+- dataconf 2.1 dataconf 2.5
+- dipy 1.7 &rarr; 1.8
+- elephant 0.14 &rarr; 1.0
+- esi-acme 2023.4 &rarr; 2023.12
+- esi-syncopy 2023.5 &rarr; 2023.9
+- h5py 3.9 &rarr; 3.10
+- mne 1.5 &rarr; 1.6
+- mne-icalabel 0.4 &rarr; 0.6
+- mne-nirs 0.5 &rarr; 0.6
+- mnelab &rarr; 0.9
+- neo 0.12 &rarr; 0.13
+- pywavelets 1.4 &rarr; 1.5
+- scikit-image 0.20 &rarr; 0.22
+- scikit-learn 1.3 &rarr; 1.4
+- scipy 1.11 &rarr; 1.12
+- spikeinterface 0.98 &rarr; 0.100
+- tensorflow 2.14 &rarr; 2.15
+- torch 2.1 &rarr; 2.2
+
+**Removed**
+
+- r-base
+- r-irkernel
+
 ## neuro-conda-2023b
 
 2nd release of neuro-conda with a few new packages and updates.

--- a/envs/neuro-conda-2023b.yml
+++ b/envs/neuro-conda-2023b.yml
@@ -1,10 +1,10 @@
-name: neuro-conda-2024a
+name: neuro-conda-2023b
 channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.11.*
-  - scipy=1.12.*
+  - python=3.10.*
+  - scipy=1.11.*
   - numpy=1.24.*
   - cython
   - numcodecs
@@ -15,14 +15,17 @@ dependencies:
   - pandas=2.1.*
   - jupyter
   - ipympl
-  - imageio=2.34.*
-  - dipy=1.8*
+  - imageio
+  - r-base=4.*
+  - r-irkernel=1.3*
+  - dipy=1.7*
   - nilearn=0.10.*
-  - mne==1.6.*
+  - mne=1.5.*
+  - mnelab=0.8.*
   - mne-realtime=0.3.*
   - mne-rsa=0.9
-  - mne-nirs=0.6.*
-  - mne-icalabel=0.6
+  - mne-nirs=0.5.*
+  - mne-icalabel=0.4
   - mne-connectivity=0.5.*
   - mne-features=0.3*
   - mne-bids-pipeline=1.4.*
@@ -34,41 +37,39 @@ dependencies:
   - eelbrain=0.39.*
   - pyprep=0.4.*
   - deid=0.3.*
+  - intensity-normalization=2.1.*
   - bokeh<3
-  - flake8=7.*
-  - pep8-naming=0.13.*
-  - black=23.11.*
+  - flake8=6.*
+  - pep8-naming=0.12.*
+  - black=23.3.*
   - brian2=2.5.*
-  - qt6-main
   - pip
-  - pip:    
-    - mnelab==0.9.*
+  - pip:
     - pytest==7.4.*
     - nixio==1.5.*
-    - h5py==3.10.*
-    - neo==0.13.*
+    - h5py==3.9.*
+    - neo==0.12.*
     - pynwb==2.5.*
-    - esi-acme==2023.12.*
-    - esi-syncopy==2023.9.*
+    - esi-acme==2023.4.*
+    - esi-syncopy==2023.5.*
     - dask==2023.3.*
-    - elephant[extras]==1.0.*
-    - viziphant==0.4.*
+    - elephant[extras]==0.14.*
+    - viziphant==0.3.*
     - neurodsp==2.2.*
-    - pywavelets==1.5.*
-    - dataconf==2.5.*
+    - pywavelets==1.4.*
+    - dataconf==2.1.*
     - fooof==1.1.*
     - bycycle==1.1.*
-    - spikeinterface[full]==0.100.*
+    - spikeinterface[full]==0.98.*
     - spikeinterface-gui==0.7.*
-    - scikit-image==0.22.*
-    - intensity-normalization==2.2.*
+    - scikit-image==0.20.*
     - torch==2.1.*; platform_system == "Linux"
     - opencv-python==4.8.*; platform_system == "Linux"
     - torchvision==0.16.*; platform_system == "Linux"
-    - torchaudio==2.2.*; platform_system == "Linux"
-    - tensorflow==2.15.*; platform_system == "Linux"
-    - tensorflow_datasets; platform_system == "Linux"
-    - scikit-learn==1.4.*; platform_system == "Linux"
+    - torchaudio==2.1.*; platform_system == "Linux"
+    - tensorflow==2.14.*; platform_system == "Linux"
+    - tensorflow_datasets
+    - scikit-learn==1.3.*; platform_system == "Linux"
     - scikit-learn-intelex; platform_machine == "x86_64" and platform_system != "Darwin"
     - spyking-circus==1.1.*
     - napari-nibabel==0.1.*
@@ -76,8 +77,8 @@ dependencies:
     - nipype==1.8.*
     - nitime==0.10.*; platform_system != "Darwin"
     - alphacsc==0.4.*
-    - sesameeg==0.0.2
-    - invertmeeg==0.0.6; platform_system == "Linux"
+    - sesameeg==0.*
+    - invertmeeg==0.*; platform_system == "Linux"
     - mat73==0.62.*
     - pynapple==0.4.*
     - suite2p==0.14.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -43,6 +43,7 @@ dependencies:
   - pep8-naming=0.12.*
   - black=23.3.*
   - brian2=2.5.*
+  - qt6-main=6.4.3
   - pip
   - pip:
     - pytest==7.4.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -44,6 +44,7 @@ dependencies:
   - pip:    
     - mnelab==0.8.*; platform_system == "Linux"
     - pytest==7.4.*
+    - ephyviewer==1.5.*
     - nixio==1.5.*
     - h5py==3.10.*
     - neo==0.13.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -66,8 +66,8 @@ dependencies:
     - opencv-python==4.8.*; platform_system == "Linux"
     - torchvision==0.17.*; platform_system == "Linux"
     - torchaudio==2.2.*; platform_system == "Linux"
-    # - tensorflow==2.15.*; platform_system == "Linux"
-    # - tensorflow_datasets; platform_system == "Linux"
+    - tensorflow==2.15.*; platform_system == "Linux"
+    - tensorflow_datasets; platform_system == "Linux"
     - scikit-learn==1.4.*; platform_system == "Linux"
     - scikit-learn-intelex; platform_machine == "x86_64" and platform_system != "Darwin"
     - spyking-circus==1.1.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -62,7 +62,7 @@ dependencies:
     - spikeinterface-gui==0.7.*
     - scikit-image==0.22.*
     - intensity-normalization==2.2.*
-    - torch==2.1.*; platform_system == "Linux"
+    - torch==2.2.*; platform_system == "Linux"
     - opencv-python==4.8.*; platform_system == "Linux"
     - torchvision==0.16.*; platform_system == "Linux"
     - torchaudio==2.2.*; platform_system == "Linux"

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -42,7 +42,7 @@ dependencies:
   - qt6-main=6.5.*
   - pip
   - pip:    
-    - mnelab==0.9.*
+    - mnelab==0.8.*
     - pytest==7.4.*
     - nixio==1.5.*
     - h5py==3.10.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -66,8 +66,8 @@ dependencies:
     - opencv-python==4.8.*; platform_system == "Linux"
     - torchvision==0.17.*; platform_system == "Linux"
     - torchaudio==2.2.*; platform_system == "Linux"
-    - tensorflow==2.15.*; platform_system == "Linux"
-    - tensorflow_datasets; platform_system == "Linux"
+    # - tensorflow==2.15.*; platform_system == "Linux"
+    # - tensorflow_datasets; platform_system == "Linux"
     - scikit-learn==1.4.*; platform_system == "Linux"
     - scikit-learn-intelex; platform_machine == "x86_64" and platform_system != "Darwin"
     - spyking-circus==1.1.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -80,5 +80,5 @@ dependencies:
     - invertmeeg==0.0.6; platform_system == "Linux"
     - mat73==0.62.*
     - pynapple==0.4.*
-    - suite2p==0.14.*
+    # - suite2p==0.14.* removed until https://github.com/MouseLand/suite2p/pull/1047 is merged
     - sbxreader==0.2.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -42,7 +42,7 @@ dependencies:
   - qt6-main=6.5.*
   - pip
   - pip:    
-    - mnelab==0.8.*
+    - mnelab==0.8.*; platform_system == "Linux"
     - pytest==7.4.*
     - nixio==1.5.*
     - h5py==3.10.*

--- a/envs/neuro-conda-latest.yml
+++ b/envs/neuro-conda-latest.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.11.*
+  - python=3.10.*
   - scipy=1.12.*
   - numpy=1.24.*
   - cython
@@ -39,7 +39,7 @@ dependencies:
   - pep8-naming=0.13.*
   - black=23.11.*
   - brian2=2.5.*
-  - qt6-main
+  - qt6-main=6.5.*
   - pip
   - pip:    
     - mnelab==0.9.*
@@ -64,7 +64,7 @@ dependencies:
     - intensity-normalization==2.2.*
     - torch==2.2.*; platform_system == "Linux"
     - opencv-python==4.8.*; platform_system == "Linux"
-    - torchvision==0.16.*; platform_system == "Linux"
+    - torchvision==0.17.*; platform_system == "Linux"
     - torchaudio==2.2.*; platform_system == "Linux"
     - tensorflow==2.15.*; platform_system == "Linux"
     - tensorflow_datasets; platform_system == "Linux"
@@ -80,5 +80,5 @@ dependencies:
     - invertmeeg==0.0.6; platform_system == "Linux"
     - mat73==0.62.*
     - pynapple==0.4.*
-    # - suite2p==0.14.* removed until https://github.com/MouseLand/suite2p/pull/1047 is merged
+    - suite2p==0.14.*
     - sbxreader==0.2.*

--- a/libexec/install.ps1
+++ b/libexec/install.ps1
@@ -60,7 +60,8 @@ If ((-not $CondaIsInstalled) -or ($Env:ncCI)){
     Invoke-WebRequest $MinicondaLatestUrl -OutFile $Env:temp\Miniconda3-latest-Windows-x86_64.exe
     Write-Debug "Done"
     Write-Host "Installing miniconda3"
-    Start-Process -WorkingDirectory "$Env:temp" -Wait -FilePath "Miniconda3-latest-Windows-x86_64.exe" -ArgumentList "/InstallationType=JustMe /S /D=$CondaInstallationDirectory"
+    
+    Start-Process -WorkingDirectory "$Env:temp" -Wait -FilePath "Miniconda3-latest-Windows-x86_64.exe" -ArgumentList "/InstallationType=JustMe /RegisterPython=1 /S /D=$CondaInstallationDirectory"
     Write-Debug "Done"
     Write-Debug "Initializing PowerShell for conda"
     Invoke-Expression "$CondaInstallationDirectory\shell\condabin\conda-hook.ps1"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -47,7 +47,8 @@ def test_imports():
          "scikit-image" : "skimage",
          "scikit-learn" : "sklearn",
          "scikit-learn-intelex" : "sklearnex",
-         "spyking-circus": "circus"
+         "spyking-circus": "circus",
+         "qt6-main": "PySide6"
     }
 
     # Split off pip-installed packages since those contain additional

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -10,15 +10,18 @@ import importlib
 import yaml
 import platform
 
+
 @pytest.mark.full
 def test_packages():
 
     # Mainly for illustration purposes: run ACME's test suite
     import acme
+
     acmePath = str(pathlib.Path(acme.__file__).resolve().parent)
     pytest.main(["-v", acmePath])
 
     return
+
 
 def test_imports():
 
@@ -29,26 +32,26 @@ def test_imports():
         ymlDict = yaml.safe_load(ymlFile)
 
     # Don't attempt to import these packages
-    ignorePkgs = ["python", "r-", "pip", "pytest", "hdf5"]
+    ignorePkgs = ["python", "r-", "pip", "pytest", "hdf5", "qt6-main"]
 
     # Additionally, don't bother trying to import these packages in a CI run
     if os.getenv("ncCI"):
-         ignorePkgs += ["invertmeeg", "torchaudio", "tensorflow"]
+        ignorePkgs += ["invertmeeg", "torchaudio", "tensorflow"]
 
     # Packages whose name does not correspond to their Python module name
     pkgMap = {
-         "esi-acme" : "acme",
-         "esi-syncopy" : "syncopy",
-         "invertmeeg" : "invert",
-         "opencv-python" : "cv2",
-         "pep8-naming": "pep8ext_naming",
-         "pybids" : "bids",
-         "pywavelets" : "pywt",
-         "scikit-image" : "skimage",
-         "scikit-learn" : "sklearn",
-         "scikit-learn-intelex" : "sklearnex",
-         "spyking-circus": "circus",
-         "qt6-main": "PySide6"
+        "esi-acme": "acme",
+        "esi-syncopy": "syncopy",
+        "invertmeeg": "invert",
+        "opencv-python": "cv2",
+        "pep8-naming": "pep8ext_naming",
+        "pybids": "bids",
+        "pywavelets": "pywt",
+        "scikit-image": "skimage",
+        "scikit-learn": "sklearn",
+        "scikit-learn-intelex": "sklearnex",
+        "spyking-circus": "circus",
+        # "qt6-main": "PySide6",
     }
 
     # Split off pip-installed packages since those contain additional
@@ -61,21 +64,31 @@ def test_imports():
         platformSpec = pkg.partition("platform_")[-1]
         platformExpr = []
         for expr in platformSpec.split("and"):
-            expr = expr.replace("machine", "machine()").replace("system", "system()").replace("platform_", "")
+            expr = (
+                expr.replace("machine", "machine()")
+                .replace("system", "system()")
+                .replace("platform_", "")
+            )
             platformExpr.append(expr)
-        if not platformSpec or all(eval("platform.%s"%(expr)) for expr in platformExpr):
+        if not platformSpec or all(
+            eval("platform.%s" % (expr)) for expr in platformExpr
+        ):
             pkgList.append(pkg.partition(";")[0])
 
     # Filter based on above ignore-list
-    pkgList = [pkg for pkg in pkgList if not any(pkg.startswith(rmpkg) for rmpkg in ignorePkgs)]
+    pkgList = [
+        pkg for pkg in pkgList if not any(pkg.startswith(rmpkg) for rmpkg in ignorePkgs)
+    ]
 
     # Remove version specifiers (if present) from package name
-    pkgList = [pkg.partition("=")[0].partition("<")[0].partition(">")[0] for pkg in pkgList]
+    pkgList = [
+        pkg.partition("=")[0].partition("<")[0].partition(">")[0] for pkg in pkgList
+    ]
 
     # Map packages to their correct module names
     for pkgName, modName in pkgMap.items():
-         if pkgName in pkgList:
-              pkgList[pkgList.index(pkgName)] = modName
+        if pkgName in pkgList:
+            pkgList[pkgList.index(pkgName)] = modName
 
     # Replace dashes (okay for package-names, not for modules) with underlines
     pkgList = [pkg.replace("-", "_") for pkg in pkgList]


### PR DESCRIPTION
## neuro-conda-2024a

3rd release of neuro-conda with a few updates.

**Updated**

- dataconf 2.1 &rarr; 2.5
- dipy 1.7 &rarr; 1.8
- elephant 0.14 &rarr; 1.0
- esi-acme 2023.4 &rarr; 2023.12
- esi-syncopy 2023.5 &rarr; 2023.9
- h5py 3.9 &rarr; 3.10
- mne 1.5 &rarr; 1.6
- mne-icalabel 0.4 &rarr; 0.6
- mne-nirs 0.5 &rarr; 0.6
- mnelab &rarr; 0.9
- neo 0.12 &rarr; 0.13
- pywavelets 1.4 &rarr; 1.5
- scikit-image 0.20 &rarr; 0.22
- scikit-learn 1.3 &rarr; 1.4
- scipy 1.11 &rarr; 1.12
- spikeinterface 0.98 &rarr; 0.100
- tensorflow 2.14 &rarr; 2.15
- torch 2.1 &rarr; 2.2

**Removed**

- r-base
- r-irkernel